### PR TITLE
Fire an event when an element is successfully attached to graph, and add inport for sending events from graph

### DIFF
--- a/lib/PolymerComponent.coffee
+++ b/lib/PolymerComponent.coffee
@@ -69,6 +69,9 @@ module.exports = (name, inports, outports) ->
         if @outPorts.element.isAttached()
           @outPorts.element.send @element
           @outPorts.element.disconnect()
+
+        @element.fire 'noflo:ready'
+
       @inPorts.element.on 'data', (@element) =>
         outports.forEach (outport) =>
           return if outport is 'element'
@@ -77,6 +80,8 @@ module.exports = (name, inports, outports) ->
         if @outPorts.element.isAttached()
           @outPorts.element.send @element
           @outPorts.element.disconnect()
+
+        @element.fire 'noflo:ready'
 
     shutdown: ->
       outports.forEach (outport) =>

--- a/lib/PolymerComponent.coffee
+++ b/lib/PolymerComponent.coffee
@@ -85,7 +85,7 @@ module.exports = (name, inports, outports) ->
           @outPorts.element.disconnect()
         @element.fire 'noflo:ready'
 
-      @inPorts.event.on 'data', (event) ->
+      @inPorts.event.on 'data', (event) =>
         @element?.fire event
 
     shutdown: ->

--- a/lib/PolymerComponent.coffee
+++ b/lib/PolymerComponent.coffee
@@ -23,6 +23,9 @@ module.exports = (name, inports, outports) ->
         element:
           datatype: 'object'
           description: 'Existing Polymer element instance'
+        event:
+          datatype: 'string'
+          description: 'Fire an event on polymer element'
       inports.forEach (inport) =>
         @inPorts.add inport,
           datatype: 'all'
@@ -80,8 +83,10 @@ module.exports = (name, inports, outports) ->
         if @outPorts.element.isAttached()
           @outPorts.element.send @element
           @outPorts.element.disconnect()
-
         @element.fire 'noflo:ready'
+
+      @inPorts.event.on 'data', (event) ->
+        @element?.fire event
 
     shutdown: ->
       outports.forEach (outport) =>

--- a/spec/PolymerElement.coffee
+++ b/spec/PolymerElement.coffee
@@ -36,7 +36,7 @@ describe 'Polymer component binding', ->
           inst = instance
           done()
       it 'should contain the required inPorts', ->
-        chai.expect(inst.inPorts.ports).to.have.keys 'element', 'selector', 'first', 'second'
+        chai.expect(inst.inPorts.ports).to.have.keys 'element', 'event', 'selector', 'first', 'second'
       it 'should contain the required outPorts', ->
         chai.expect(inst.outPorts.ports).to.have.keys 'element', 'error', 'result'
     describe 'on instantiation', ->
@@ -82,7 +82,7 @@ describe 'Polymer component binding', ->
           inst = instance
           done()
       it 'should contain the required inPorts', ->
-        chai.expect(inst.inPorts.ports).to.have.keys 'element', 'selector', 'first', 'second'
+        chai.expect(inst.inPorts.ports).to.have.keys 'element', 'event', 'selector', 'first', 'second'
       it 'should contain the required outPorts', ->
         chai.expect(inst.outPorts.ports).to.have.keys 'element', 'error', 'event'
     describe 'on instantiation', ->


### PR DESCRIPTION
This pull request allows polymer elements to wait to be attached to a noflo graph to send events that are intended to be received by the graph, and adds an inport for sending more events to the element.
