### PR TITLE
Send events as objects instead of with brackets

### DIFF
--- a/lib/PolymerComponent.js
+++ b/lib/PolymerComponent.js
@@ -14,14 +14,10 @@ const bindAllEvents = (element, port, outports) => {
       originalFire(event, detail, toNode);
       return;
     }
-    const groups = event.split(':');
-    groups.forEach((grp) => {
-      port.beginGroup(grp);
-    });
     const value = (detail && detail.value) ? detail.value : detail;
-    port.send(value);
-    groups.forEach(() => {
-      port.endGroup();
+    port.send({
+      action: event,
+      payload: value,
     });
     originalFire(event, detail, toNode);
   };

--- a/spec/PolymerElement.js
+++ b/spec/PolymerElement.js
@@ -125,13 +125,11 @@ describe('Polymer component binding', function() {
       after(() => inst.outPorts.event.detach(event));
       it('should send to outport', function(done) {
         const groups = [];
-        event.on('begingroup', group => groups.push(group));
-        event.on('endgroup', () => groups.pop());
         event.on('data', function(data) {
-          chai.expect(data).to.equal(5);
-          chai.expect(groups).to.eql([
-            'result'
-          ]);
+          chai.expect(data).to.eql({
+            action: 'result',
+            payload: 5
+          });
           inst.outPorts.event.detach(event);
           done();
         });


### PR DESCRIPTION
Brackets are the wrong mechanism for packet metadata. We did the same in https://github.com/noflo/noflo-ui/pull/767